### PR TITLE
Actualizar fechas y agregar certificaciones en la sección de experiencia (2026)

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,18 +140,38 @@
         <div class="timeline">
             <div class="timeline-item">
                 <h3>Ingeniero de Sistemas - UNAD</h3>
-                <p class="timeline-date">2024</p>
+                <p class="timeline-date">2026</p>
                 <p>Título profesional con énfasis en desarrollo backend, análisis de datos y seguridad aplicada.</p>
             </div>
             <div class="timeline-item">
                 <h3>Especialización en Seguridad Informática (en curso)</h3>
-                <p class="timeline-date">2024 - Actual</p>
+                <p class="timeline-date">2026</p>
                 <p>Profundización en protección de datos, redes y sistemas con mejores prácticas de ciberseguridad.</p>
             </div>
             <div class="timeline-item">
                 <h3>Análisis de datos con Python</h3>
-                <p class="timeline-date">2023</p>
+                <p class="timeline-date">2026</p>
                 <p>Procesamiento con NumPy y Pandas; visualización y storytelling de datos con Power BI.</p>
+            </div>
+            <div class="timeline-item">
+                <h3>Cisco Packet Tracer</h3>
+                <p class="timeline-date">2026</p>
+                <p>Certificado emitido por Cisco Networking Academy.</p>
+            </div>
+            <div class="timeline-item">
+                <h3>Power BI</h3>
+                <p class="timeline-date">2026</p>
+                <p>Certificación emitida por Santander Open Academy.</p>
+            </div>
+            <div class="timeline-item">
+                <h3>Introducción a seguridad informática</h3>
+                <p class="timeline-date">2026</p>
+                <p>Certificado emitido por Cisco Networking Academy.</p>
+            </div>
+            <div class="timeline-item">
+                <h3>EXPOTECH</h3>
+                <p class="timeline-date">Marzo 2026</p>
+                <p>Universidad Nacional Abierta y a Distancia. Presentando proyectos en torno a la aplicación de la ingeniería de sistemas y la seguridad informática para el desarrollo sostenible.</p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
### Motivation
- Estandarizar las fechas de la sección "Experiencia y certificaciones" a 2026 según la solicitud de actualización. 
- Añadir nuevas certificaciones y un registro de participación en EXPOTECH para reflejar formación y eventos recientes.

### Description
- Actualiza el archivo `index.html` modificando las fechas de varias entradas de la línea de tiempo a `2026` y agregando nuevas entradas de certificaciones. 
- Cambia las fechas de: "Ingeniero de Sistemas - UNAD", "Especialización en Seguridad Informática (en curso)" y "Análisis de datos con Python" a `2026`.
- Agrega las entradas: "Cisco Packet Tracer" (2026), "Power BI" (2026, emitido por Santander Open Academy), "Introducción a seguridad informática" (2026, Cisco Networking Academy) y "EXPOTECH" (`Marzo 2026`) con la descripción proporcionada. 
- El cambio afectó a un solo archivo (`index.html`) y el commit resultante muestra 23 inserciones y 3 eliminaciones.

### Testing
- Se arrancó un servidor local con `python -m http.server` para servir el sitio y fue iniciado correctamente. 
- Se intentó generar una captura con Playwright pero la primera ejecución expiró por timeout y la segunda falló porque Chromium se cerró inesperadamente (SIGSEGV), por lo que la verificación visual automática falló. 
- No se ejecutaron otras pruebas automatizadas ya que los cambios son principalmente de contenido HTML.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69874381c6048329a0a47f1538c79c5f)