### PR TITLE
Transforma sección de habilidades a flashcards interactivas

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,66 +179,66 @@
     <section class="skills" id="skills">
         <h2>Habilidades</h2>
         <div class="skills-list">
-            <div class="skill-item">
-                <div class="skill-header">
-                    <span class="skill-title">C#</span>
-                    <span class="skill-percentage">85%</span>
+            <article class="skill-item" tabindex="0" aria-label="Tarjeta de habilidad: C# y .NET">
+                <div class="skill-card-inner">
+                    <div class="skill-face skill-front">
+                        <h3 class="skill-title">C# y .NET</h3>
+                    </div>
+                    <div class="skill-face skill-back">
+                        <p class="skill-description">Desarrollo APIs REST seguras con arquitectura limpia, autenticación robusta y pruebas unitarias.</p>
+                    </div>
                 </div>
-                <div class="progress-bar">
-                    <div class="progress-fill" data-percentage="85"></div>
+            </article>
+            <article class="skill-item" tabindex="0" aria-label="Tarjeta de habilidad: Python y automatización">
+                <div class="skill-card-inner">
+                    <div class="skill-face skill-front">
+                        <h3 class="skill-title">Python y automatización</h3>
+                    </div>
+                    <div class="skill-face skill-back">
+                        <p class="skill-description">Automatizo tareas técnicas y análisis de datos con scripts eficientes usando Pandas y NumPy.</p>
+                    </div>
                 </div>
-                <p class="skill-description">Creo APIs REST seguras con .NET, autenticación sólida y pruebas unitarias que aseguran disponibilidad.</p>
-            </div>
-            <div class="skill-item">
-                <div class="skill-header">
-                    <span class="skill-title">Python</span>
-                    <span class="skill-percentage">80%</span>
+            </article>
+            <article class="skill-item" tabindex="0" aria-label="Tarjeta de habilidad: SQL y NoSQL">
+                <div class="skill-card-inner">
+                    <div class="skill-face skill-front">
+                        <h3 class="skill-title">SQL y NoSQL</h3>
+                    </div>
+                    <div class="skill-face skill-back">
+                        <p class="skill-description">Modelo y consulto datos en MySQL y MongoDB con enfoque en integridad, rendimiento y escalabilidad.</p>
+                    </div>
                 </div>
-                <div class="progress-bar">
-                    <div class="progress-fill" data-percentage="80"></div>
+            </article>
+            <article class="skill-item" tabindex="0" aria-label="Tarjeta de habilidad: Seguridad informática">
+                <div class="skill-card-inner">
+                    <div class="skill-face skill-front">
+                        <h3 class="skill-title">Seguridad informática</h3>
+                    </div>
+                    <div class="skill-face skill-back">
+                        <p class="skill-description">Aplico buenas prácticas de hardening, protección de datos y seguridad en aplicaciones y redes.</p>
+                    </div>
                 </div>
-                <p class="skill-description">Automatizo tareas y analizo datos con Pandas y NumPy, generando scripts de hardening y reportes rápidos.</p>
-            </div>
-            <div class="skill-item">
-                <div class="skill-header">
-                    <span class="skill-title">MySQL</span>
-                    <span class="skill-percentage">75%</span>
+            </article>
+            <article class="skill-item" tabindex="0" aria-label="Tarjeta de habilidad: Power BI y BI">
+                <div class="skill-card-inner">
+                    <div class="skill-face skill-front">
+                        <h3 class="skill-title">Power BI y BI</h3>
+                    </div>
+                    <div class="skill-face skill-back">
+                        <p class="skill-description">Construyo dashboards con KPIs accionables para análisis, storytelling de datos y toma de decisiones.</p>
+                    </div>
                 </div>
-                <div class="progress-bar">
-                    <div class="progress-fill" data-percentage="75"></div>
+            </article>
+            <article class="skill-item" tabindex="0" aria-label="Tarjeta de habilidad: Git y colaboración">
+                <div class="skill-card-inner">
+                    <div class="skill-face skill-front">
+                        <h3 class="skill-title">Git y colaboración</h3>
+                    </div>
+                    <div class="skill-face skill-back">
+                        <p class="skill-description">Gestiono control de versiones, trabajo por ramas y entregas colaborativas con buenas prácticas.</p>
+                    </div>
                 </div>
-                <p class="skill-description">Modelo esquemas normalizados y consultas optimizadas para reportes confiables y datos íntegros.</p>
-            </div>
-            <div class="skill-item">
-                <div class="skill-header">
-                    <span class="skill-title">MongoDB</span>
-                    <span class="skill-percentage">70%</span>
-                </div>
-                <div class="progress-bar">
-                    <div class="progress-fill" data-percentage="70"></div>
-                </div>
-                <p class="skill-description">Diseño colecciones flexibles y pipelines de agregación para dashboards en tiempo real.</p>
-            </div>
-            <div class="skill-item">
-                <div class="skill-header">
-                    <span class="skill-title">Power BI</span>
-                    <span class="skill-percentage">78%</span>
-                </div>
-                <div class="progress-bar">
-                    <div class="progress-fill" data-percentage="78"></div>
-                </div>
-                <p class="skill-description">Construyo dashboards interactivos con KPIs accionables para decisiones ágiles del negocio.</p>
-            </div>
-            <div class="skill-item">
-                <div class="skill-header">
-                    <span class="skill-title">Git</span>
-                    <span class="skill-percentage">90%</span>
-                </div>
-                <div class="progress-bar">
-                    <div class="progress-fill" data-percentage="90"></div>
-                </div>
-                <p class="skill-description">Gestiono ramas, revisiones y despliegues coordinados para entregas seguras en equipo.</p>
-            </div>
+            </article>
         </div>
     </section>
 

--- a/main.js
+++ b/main.js
@@ -132,33 +132,6 @@ document.getElementById('contact-form').addEventListener('submit', function(e) {
     });
 });
 
-// Animate progress bars on scroll
-function animateProgressBars() {
-    const skillsSection = document.querySelector('.skills');
-    const observer = new IntersectionObserver(
-        entries => {
-            entries.forEach(entry => {
-                if (entry.isIntersecting) {
-                    const progressFills = entry.target.querySelectorAll('.progress-fill');
-                    progressFills.forEach(fill => {
-                        const percentage = fill.getAttribute('data-percentage');
-                        fill.style.width = percentage + '%';
-                    });
-                    observer.unobserve(entry.target);
-                }
-            });
-        },
-        { threshold: 0.5 }
-    );
-
-    if (skillsSection) {
-        observer.observe(skillsSection);
-    }
-}
-
-// Initialize progress bars animation
-animateProgressBars();
-
 // Typewriter effect for name
 function typewriterEffect() {
     const element = document.getElementById('typewriter');

--- a/styles.css
+++ b/styles.css
@@ -372,72 +372,60 @@ h2 {
 }
 
 .skill-item {
-    background: rgba(var(--accent-rgb), 0.02);
-    border: 1px solid var(--border);
-    padding: 1rem 1.2rem;
-    border-radius: 12px;
-    transition: all 0.3s ease;
+    min-height: 190px;
+    perspective: 1000px;
     position: relative;
 }
 
-.skill-item:hover {
-    border-color: rgba(var(--accent-rgb), 0.32);
-    transform: translateY(-2px);
-    box-shadow: 0 10px 30px rgba(var(--accent-rgb), 0.12);
+.skill-card-inner {
+    width: 100%;
+    height: 100%;
+    border-radius: 14px;
+    transition: transform 0.6s;
+    transform-style: preserve-3d;
+    position: relative;
 }
 
-.skill-header {
+.skill-item:hover .skill-card-inner,
+.skill-item:focus-within .skill-card-inner {
+    transform: rotateY(180deg);
+}
+
+.skill-face {
+    position: absolute;
+    inset: 0;
+    border-radius: 14px;
+    border: 1px solid var(--border);
+    background: rgba(var(--accent-rgb), 0.04);
+    box-shadow: 0 10px 28px rgba(var(--accent-rgb), 0.12);
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    margin-bottom: 0.5rem;
+    justify-content: center;
+    text-align: center;
+    padding: 1rem;
+    backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
+}
+
+.skill-front {
+    background: linear-gradient(135deg, rgba(var(--accent-rgb), 0.16), rgba(var(--accent-rgb), 0.05));
+}
+
+.skill-back {
+    transform: rotateY(180deg);
+    background: var(--gradient-surface);
 }
 
 .skill-title {
     font-weight: 700;
     color: var(--text);
-    cursor: pointer;
-    transition: color 0.3s ease;
-}
-
-.skill-title:hover { color: var(--accent); }
-
-.skill-percentage {
-    font-weight: 700;
-    color: var(--accent);
-}
-
-.progress-bar {
-    width: 100%;
-    height: 8px;
-    background: rgba(var(--accent-rgb), 0.1);
-    border-radius: 4px;
-    overflow: hidden;
-}
-
-.progress-fill {
-    height: 100%;
-    background: linear-gradient(90deg, var(--accent), rgba(var(--accent-rgb), 0.82));
-    border-radius: 4px;
-    width: 0%;
-    transition: width 1.5s ease-out;
+    font-size: 1.1rem;
 }
 
 .skill-description {
-    display: block;
-    margin-top: 0.5rem;
     color: var(--muted);
-    font-size: 0.92rem;
+    font-size: 0.95rem;
     line-height: 1.5;
-    opacity: 0;
-    transform: translateY(6px);
-    transition: opacity 0.25s ease, transform 0.25s ease;
-}
-
-.skill-item:hover .skill-description,
-.skill-item:focus-within .skill-description {
-    opacity: 1;
-    transform: translateY(0);
 }
 
 .projects-link,


### PR DESCRIPTION
### Motivation
- Sustituir la presentación basada en porcentajes y barras de progreso por una UI más clara e interactiva: tarjetas tipo flashcard que muestran la descripción al girar. 
- Alinear las habilidades mostradas con el perfil del proyecto (C#/.NET, Python, SQL/NoSQL, Seguridad informática, Power BI, Git) y mejorar la accesibilidad. 

### Description
- Reemplacé los bloques de habilidades en `index.html` por `article.skill-item` con estructura `skill-card-inner` y caras `skill-front` / `skill-back`, y añadí `tabindex="0"` y `aria-label` para soporte por teclado. 
- Eliminé los elementos de porcentaje y barras (`skill-percentage`, `progress-bar`, `progress-fill`) de la sección de habilidades. 
- Añadí estilos 3D en `styles.css` (perspective, `transform-style: preserve-3d`, caras front/back, rotación `rotateY(180deg)` en `:hover` / `:focus-within`) y retiré CSS asociado al modelo de progreso. 
- Eliminé en `main.js` la función `animateProgressBars()` y su inicialización ya que dejó de ser necesaria. 

### Testing
- Busqué referencias residuales a clases antiguas con búsquedas (`rg`) y no quedaron coincidencias relacionadas con `skill-percentage`, `progress-fill`, `progress-bar` ni `skill-header` (resultado: limpio). 
- Ejecuté `git diff --check` y no hubo advertencias de estilo o conflictos (ok). 
- Serví el sitio localmente con `python3 -m http.server --directory /workspace/Blacktechsec_Page` y verifiqué visualmente mediante un script Playwright que la tarjeta gira en `:hover`/`focus`, generando una captura (`artifacts/skills-flashcards.png`) (ok). 
- Todas las comprobaciones automáticas realizadas dentro del repo pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996710f0d58832983b226ec1c2617bc)