### PR TITLE
Update homepage content, CV link, skills lists, and project details

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,9 +93,9 @@
                 </div>
                 <h1 id="typewriter">Jair Alexis Martinez</h1>
                 <p class="role-headline">Ingeniero de Sistemas | Ciberseguridad | Backend | Data</p>
-                <p>Ingeniero de Sistemas enfocado en desarrollo backend, análisis de datos y ciberseguridad. Experiencia práctica construyendo y documentando laboratorios técnicos con C# y Python, automatizando tareas y analizando registros (logs) para identificar eventos de seguridad. Manejo de bases de datos SQL y NoSQL, y elaboración de reportes en Power BI. Actualmente curso una Especialización en Seguridad Informática, fortaleciendo competencias en protección de datos, redes, sistemas y análisis de incidentes. Perfil analítico, autónomo y orientado a resultados.</p>
+                <p>Ingeniero de Sistemas enfocado en desarrollo backend, análisis de datos y ciberseguridad. Experiencia práctica construyendo y documentando laboratorios técnicos con C# y Python, automatizando tareas y analizando registros (logs) para identificar eventos de seguridad. Manejo de bases de datos SQL y NoSQL, y elaboración de reportes en Power BI. Actualmente curso una Especialización en Seguridad Informática, fortaleciendo competencias en protección de datos, redes, sistemas y análisis de incidentes.</p>
                 <div class="hero-actions">
-                    <a class="projects-link primary" href="/cv.pdf" target="_blank" rel="noopener noreferrer">Descargar CV</a>
+                    <a class="projects-link primary" href="/Curr%C3%ADculum%20Vitae.pdf" target="_blank" rel="noopener noreferrer">Descargar CV</a>
                     <a class="projects-link primary" href="https://github.com/alexis2487" target="_blank" rel="noopener noreferrer">
                         <!-- GitHub SVG -->
                         <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.387.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.612-4.042-1.612-.546-1.387-1.333-1.756-1.333-1.756-1.09-.745.083-.729.083-.729 1.205.084 1.84 1.237 1.84 1.237 1.07 1.834 2.807 1.304 3.492.997.108-.775.418-1.304.76-1.604-2.665-.305-5.466-1.332-5.466-5.93 0-1.31.468-2.382 1.236-3.222-.123-.303-.536-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.289-1.552 3.295-1.23 3.295-1.23.655 1.653.242 2.874.12 3.176.77.84 1.235 1.913 1.235 3.222 0 4.61-2.807 5.624-5.479 5.921.43.371.815 1.102.815 2.222 0 1.606-.015 2.896-.015 3.286 0 .32.216.694.825.576C20.565 22.092 24 17.592 24 12.297 24 5.67 18.627.297 12 .297z"/></svg>
@@ -126,7 +126,7 @@
 
     <section class="about" id="about">
         <h2>Perfil</h2>
-        <p>Ingeniero de Sistemas enfocado en desarrollo backend, análisis de datos y ciberseguridad. Experiencia práctica construyendo y documentando laboratorios técnicos con C# y Python, automatizando tareas y analizando registros (logs) para identificar eventos de seguridad. Manejo de bases de datos SQL y NoSQL, y elaboración de reportes en Power BI. Actualmente curso una Especialización en Seguridad Informática, fortaleciendo competencias en protección de datos, redes, sistemas y análisis de incidentes. Perfil analítico, autónomo y orientado a resultados.</p>
+        <p>Ingeniero de Sistemas de la UNAD y estudiante de Especialización en Seguridad Informática. Enfocado en backend, análisis de datos y ciberseguridad aplicada. He desarrollado y documentado laboratorios técnicos con C# y Python, automatizando tareas y analizando logs para identificar eventos de seguridad. Manejo SQL/NoSQL (incluyendo MongoDB) y construyo reportes en Power BI para apoyar análisis y toma de decisiones. Me caracterizo por un enfoque analítico, aprendizaje autónomo y orientación a resultados.</p>
     </section>
 
     <section class="education" id="education">
@@ -139,13 +139,13 @@
         <h2>Experiencia y certificaciones</h2>
         <div class="timeline">
             <div class="timeline-item">
-                <h3>Ingeniero de Sistemas - UNAD</h3>
-                <p class="timeline-date">2026</p>
-                <p>Título profesional con énfasis en desarrollo backend, análisis de datos y seguridad aplicada.</p>
+                <h3>Ingeniería de Sistemas - UNAD (último semestre)</h3>
+                <p class="timeline-date">En curso</p>
+                <p>Formación profesional con énfasis en desarrollo backend, análisis de datos y seguridad aplicada.</p>
             </div>
             <div class="timeline-item">
-                <h3>Especialización en Seguridad Informática (en curso)</h3>
-                <p class="timeline-date">2026</p>
+                <h3>Especialización en Seguridad Informática</h3>
+                <p class="timeline-date">En curso</p>
                 <p>Profundización en protección de datos, redes y sistemas con mejores prácticas de ciberseguridad.</p>
             </div>
             <div class="timeline-item">
@@ -170,7 +170,7 @@
             </div>
             <div class="timeline-item">
                 <h3>EXPOTECH</h3>
-                <p class="timeline-date">Marzo 2026</p>
+                <p class="timeline-date">Marzo 2025</p>
                 <p>Universidad Nacional Abierta y a Distancia. Presentando proyectos en torno a la aplicación de la ingeniería de sistemas y la seguridad informática para el desarrollo sostenible.</p>
             </div>
         </div>
@@ -181,35 +181,35 @@
         <div class="skills-list">
             <article class="skill-item" aria-label="Programación">
                 <h3 class="skill-title">Programación</h3>
-                <p class="skill-description">Python, C#</p>
+                <ul class="skill-bullets"><li>Python</li><li>C#</li></ul>
             </article>
             <article class="skill-item" aria-label="Backend">
                 <h3 class="skill-title">Backend</h3>
-                <p class="skill-description">Desarrollo de APIs, manejo de datos, procesamiento de información</p>
+                <ul class="skill-bullets"><li>Desarrollo de APIs</li><li>Manejo de datos</li><li>Procesamiento de información</li></ul>
             </article>
             <article class="skill-item" aria-label="Bases de datos">
                 <h3 class="skill-title">Bases de datos</h3>
-                <p class="skill-description">SQL, NoSQL, MongoDB</p>
+                <ul class="skill-bullets"><li>SQL</li><li>NoSQL</li><li>MongoDB</li></ul>
             </article>
             <article class="skill-item" aria-label="Ciberseguridad">
                 <h3 class="skill-title">Ciberseguridad</h3>
-                <p class="skill-description">Monitoreo, análisis de logs, análisis de eventos, gestión de incidentes (práctica académica)</p>
+                <ul class="skill-bullets"><li>Monitoreo</li><li>Análisis de logs</li><li>Análisis de eventos de seguridad</li><li>Gestión de incidentes (nivel académico/práctico)</li></ul>
             </article>
             <article class="skill-item" aria-label="Sistemas operativos">
                 <h3 class="skill-title">Sistemas operativos</h3>
-                <p class="skill-description">Linux, Windows</p>
+                <ul class="skill-bullets"><li>Linux</li><li>Windows</li></ul>
             </article>
             <article class="skill-item" aria-label="Análisis y BI">
                 <h3 class="skill-title">Análisis y BI</h3>
-                <p class="skill-description">Power BI, consultas SQL, visualización</p>
+                <ul class="skill-bullets"><li>Consultas SQL</li><li>Visualización y reportes en Power BI</li></ul>
             </article>
             <article class="skill-item" aria-label="Automatización e IA">
                 <h3 class="skill-title">Automatización e IA</h3>
-                <p class="skill-description">Microsoft Copilot Agents</p>
+                <ul class="skill-bullets"><li>Microsoft Copilot Agents</li></ul>
             </article>
             <article class="skill-item" aria-label="Control de versiones">
                 <h3 class="skill-title">Control de versiones</h3>
-                <p class="skill-description">Git, GitHub</p>
+                <ul class="skill-bullets"><li>Git</li><li>GitHub</li></ul>
             </article>
         </div>
     </section>
@@ -220,37 +220,42 @@
         <div class="projects-grid">
             <article class="project-item">
                 <h3>Prototipo de diagnóstico de madurez en ciberseguridad para MiPymes</h3>
-                <p>Prototipo web para evaluar madurez en ciberseguridad en MiPymes con cuestionario automatizado, panel seguro, reportes PDF y despliegue en contenedor; validado en entorno real.</p>
+                <p>Prototipo web para evaluar la madurez en ciberseguridad en MiPymes, incorporando cuestionario automatizado, panel seguro de resultados, generación de reportes PDF y despliegue en contenedor. Validado en un entorno real.</p>
                 <div class="project-tags">
-                    <span>Python</span><span>Web Backend</span><span>SQL/NoSQL</span><span>Security</span><span>PDF Reports</span><span>Container</span>
+                    <span>Python</span><span>Web Backend</span><span>SQL/NoSQL</span><span>PDF</span><span>Container</span><span>Security</span>
                 </div>
                 <div class="project-actions">
                     <a href="https://github.com/alexis2487" target="_blank" rel="noopener noreferrer" class="projects-link">Ver en GitHub</a>
-                    <a href="#contact" class="projects-link ghost">Detalles</a>
+                    <a href="#project-a" class="projects-link ghost">Detalles</a>
                 </div>
             </article>
             <article class="project-item">
-                <h3>Laboratorios de Ciberseguridad y Sistemas</h3>
-                <p>Implementación y documentación de laboratorios prácticos: Linux, automatización con Python, análisis de logs y eventos de seguridad.</p>
+                <h3>Proyectos y laboratorios de ciberseguridad y sistemas</h3>
+                <p>Implementación y documentación de laboratorios prácticos de ciberseguridad; administración de servidores Linux; automatización con Python; análisis de eventos y logs; consultas SQL/NoSQL; reportes en Power BI.</p>
                 <div class="project-tags">
-                    <span>Linux</span><span>Python</span><span>Logs</span><span>Security</span>
+                    <span>Linux</span><span>Python</span><span>Logs</span><span>Security</span><span>SQL/NoSQL</span>
                 </div>
                 <div class="project-actions">
                     <a href="https://github.com/alexis2487" target="_blank" rel="noopener noreferrer" class="projects-link">Ver en GitHub</a>
-                    <a href="#contact" class="projects-link ghost">Detalles</a>
+                    <a href="#project-b" class="projects-link ghost">Detalles</a>
                 </div>
             </article>
             <article class="project-item">
                 <h3>Automatización y análisis de datos</h3>
-                <p>Scripts en Python para automatizar tareas y apoyar análisis de datos y reportes.</p>
+                <p>Scripts en Python para automatización, procesamiento de datos y apoyo al análisis y reportes.</p>
                 <div class="project-tags">
-                    <span>Python</span><span>Data Analysis</span><span>Automation</span>
+                    <span>Python</span><span>Automation</span><span>Data Analysis</span>
                 </div>
                 <div class="project-actions">
                     <a href="https://github.com/alexis2487" target="_blank" rel="noopener noreferrer" class="projects-link">Ver en GitHub</a>
-                    <a href="#contact" class="projects-link ghost">Detalles</a>
+                    <a href="#project-c" class="projects-link ghost">Detalles</a>
                 </div>
             </article>
+        </div>
+        <div class="project-details">
+            <p id="project-a"><strong>Detalle:</strong> Prototipo de evaluación de madurez para MiPymes con cuestionario automatizado, panel seguro y generación de reportes.</p>
+            <p id="project-b"><strong>Detalle:</strong> Portafolio técnico de laboratorios con enfoque en seguridad aplicada, administración Linux, logs y datos.</p>
+            <p id="project-c"><strong>Detalle:</strong> Scripts para automatización y preparación de datos orientados a análisis y reportes.</p>
         </div>
         <a href="https://github.com/alexis2487" target="_blank" rel="noopener noreferrer" class="projects-link">
             <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="currentColor" style="vertical-align:middle;margin-right:.45rem"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.387.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.612-4.042-1.612-.546-1.387-1.333-1.756-1.333-1.756-1.09-.745.083-.729.083-.729 1.205.084 1.84 1.237 1.84 1.237 1.07 1.834 2.807 1.304 3.492.997.108-.775.418-1.304.76-1.604-2.665-.305-5.466-1.332-5.466-5.93 0-1.31.468-2.382 1.236-3.222-.123-.303-.536-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.289-1.552 3.295-1.23 3.295-1.23.655 1.653.242 2.874.12 3.176.77.84 1.235 1.913 1.235 3.222 0 4.61-2.807 5.624-5.479 5.921.43.371.815 1.102.815 2.222 0 1.606-.015 2.896-.015 3.286 0 .32.216.694.825.576C20.565 22.092 24 17.592 24 12.297 24 5.67 18.627.297 12 .297z"/></svg>
@@ -266,7 +271,7 @@
             <li><strong>Email:</strong> <a href="mailto:alexis.martinez_systems.engineer@outlook.com">alexis.martinez_systems.engineer@outlook.com</a></li>
             <li><strong>LinkedIn:</strong> <a href="https://www.linkedin.com/in/jair-alexis-martinez-302b78305" target="_blank" rel="noopener noreferrer">linkedin.com/in/jair-alexis-martinez-302b78305</a></li>
             <li><strong>GitHub:</strong> <a href="https://github.com/alexis2487" target="_blank" rel="noopener noreferrer">github.com/alexis2487</a></li>
-            <li><strong>Website:</strong> <a href="https://www.blacktechsec.com" target="_blank" rel="noopener noreferrer">https://www.blacktechsec.com</a></li>
+            <li><strong>Sitio web:</strong> <a href="https://www.blacktechsec.com" target="_blank" rel="noopener noreferrer">https://www.blacktechsec.com</a></li>
         </ul>
         <form id="contact-form" action="https://formsubmit.co/alexis.martinez_systems.engineer@outlook.com" method="POST" aria-labelledby="contact-heading">
             <div class="form-group">
@@ -289,7 +294,7 @@
     </section>
 
     <footer>
-        <a class="projects-link primary" href="/cv.pdf" target="_blank" rel="noopener noreferrer">Descargar CV</a>
+        <a class="projects-link primary" href="/Curr%C3%ADculum%20Vitae.pdf" target="_blank" rel="noopener noreferrer">Descargar CV</a>
         <div class="social-links">
             <a href="https://www.linkedin.com/in/jair-alexis-martinez-302b78305" target="_blank" rel="noopener noreferrer">
                 <!-- LinkedIn SVG -->

--- a/styles.css
+++ b/styles.css
@@ -394,10 +394,14 @@ h2 {
     font-size: 1.1rem;
 }
 
-.skill-description {
+.skill-bullets {
+    margin: 0.65rem 0 0;
+    padding-left: 1.1rem;
     color: var(--muted);
+    display: grid;
+    gap: 0.35rem;
     font-size: 0.95rem;
-    line-height: 1.5;
+    line-height: 1.45;
 }
 
 .projects-link,
@@ -513,6 +517,21 @@ h2 {
     padding: 0.35rem 0.6rem;
     border-radius: 999px;
     background: rgba(var(--accent-rgb), 0.08);
+}
+
+
+.project-details {
+    display: grid;
+    gap: 0.65rem;
+    margin-bottom: 1.5rem;
+}
+
+.project-details p {
+    border-left: 3px solid rgba(var(--accent-rgb), 0.35);
+    padding: 0.65rem 0.85rem;
+    background: rgba(var(--accent-rgb), 0.04);
+    color: var(--muted);
+    border-radius: 8px;
 }
 
 .contact { max-width: 640px; margin: 2rem auto; }


### PR DESCRIPTION
### Motivation
- Refresh personal website content to better reflect current education, skills and project details.
- Improve navigation and anchor targets for project details and normalize the downloadable CV filename.
- Replace dense paragraph skill descriptions with clearer list items for readability and accessibility.

### Description
- Updated `index.html` hero and about texts to refine the profile, add university name, and remove a duplicated sentence in the hero paragraph.
- Replaced CV links to point to the URL-encoded file `Curr%C3%ADculum%20Vitae.pdf` in the header and footer.
- Adjusted education and timeline entries (changed labels to "En curso" and updated `EXPOTECH` date to March 2025) and clarified roles/labels.
- Converted skill paragraph blocks into unordered lists and updated class usage from `.skill-description` to `.skill-bullets`, added project anchor links and a new project details section in `index.html`.
- Updated `styles.css` to style the new `.skill-bullets` and added `.project-details` styles for the new project detail blocks.
- Minor copy and label changes (e.g., "Website" → "Sitio web") and reordering/tag cleanup in project tags.

### Testing
- No automated tests were run for these content and style updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a900dfc3848329b9b87b408329597e)