### PR TITLE
Remove '(último semestre)' from education and experience text

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
 
     <section class="education" id="education">
         <h2>Educación</h2>
-        <p><strong>UNAD</strong> - Ingeniería de Sistemas (último semestre)</p>
+        <p><strong>UNAD</strong> - Ingeniería de Sistemas</p>
         <p><strong>UNAD</strong> - Especialización en Seguridad Informática (en curso)</p>
     </section>
 
@@ -139,7 +139,7 @@
         <h2>Experiencia y certificaciones</h2>
         <div class="timeline">
             <div class="timeline-item">
-                <h3>Ingeniería de Sistemas - UNAD (último semestre)</h3>
+                <h3>Ingeniería de Sistemas - UNAD</h3>
                 <p class="timeline-date">En curso</p>
                 <p>Formación profesional con énfasis en desarrollo backend, análisis de datos y seguridad aplicada.</p>
             </div>


### PR DESCRIPTION
### Motivation
- Remove the parenthetical `(último semestre)` from the education and experience sections so the resume content reads as current and consistent.

### Description
- Updated `index.html` to replace `UNAD - Ingeniería de Sistemas (último semestre)` with `UNAD - Ingeniería de Sistemas` and `Ingeniería de Sistemas - UNAD (último semestre)` with `Ingeniería de Sistemas - UNAD` (1 file modified).

### Testing
- Verified the edits with `rg -n "último semestre|ultimo semestre|UNAD - Ingeniería de Sistemas|Ingeniería de Sistemas - UNAD" .` and inspected the change via `git diff -- index.html`, committed the change, and attempted to serve the site with `python3 -m http.server 4173` and capture a screenshot with Playwright but the Playwright navigation step failed with `ERR_EMPTY_RESPONSE`/`ERR_FILE_NOT_FOUND` while the text replacements and commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3a9edd68c8329bdf969df51a0f1f5)